### PR TITLE
[Android] Allow re-use of socket port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.5.1] - 2019-08-09
+
+- [Android] Set option to re-use previously bound port during socket shutdown timeout
+
 ## [1.5.0] - 2019-04-02
 
 - [Android] upgrading to [org:java-websocket:1.4.0](https://github.com/TooTallNate/Java-WebSocket)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+# Reasons for Wattcost use:
+- [Android] Allow reuse of port during socket shutdown timeout as outlined here: https://github.com/TooTallNate/Java-WebSocket/wiki/Enable-SO_REUSEADDR
+
 # Cordova WebSocket Server Plugin
 
 This plugin allows you to run a single, lightweight, barebone WebSocket Server from applications developed using PhoneGap/Cordova 3.0 or newer.
@@ -101,7 +104,7 @@ wsserver.getInterfaces(function(result) {
 It depends on [the TooTallNate WebSocket Server](https://github.com/TooTallNate/Java-WebSocket).
 
 #### iOS
-It depends on [the couchbasedeps PocketSocket Server](https://github.com/couchbasedeps/PocketSocket) forked from [the zwopple PocketSocket Server](https://github.com/zwopple/PocketSocket). 
+It depends on [the couchbasedeps PocketSocket Server](https://github.com/couchbasedeps/PocketSocket) forked from [the zwopple PocketSocket Server](https://github.com/zwopple/PocketSocket).
 
 ## Licence ##
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "cordova-plugin-websocket-server",
-    "version": "1.5.0",
+    "version": "1.5.1",
     "description": "Cordova WebSocket Server Plugin",
     "cordova": {
         "id": "cordova-plugin-websocket-server",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,8 +1,8 @@
-<?xml version="1.0" encoding="UTF-8"?> 
+<?xml version="1.0" encoding="UTF-8"?>
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="cordova-plugin-websocket-server"
-    version="1.5.0">
+    version="1.5.1">
 
     <name>WebSocket Server</name>
     <description>WebSocket Server plugin for Cordova/Phonegap</description>

--- a/src/android/net/becvert/cordova/WebSocketServerPlugin.java
+++ b/src/android/net/becvert/cordova/WebSocketServerPlugin.java
@@ -155,6 +155,8 @@ public class WebSocketServerPlugin extends CordovaPlugin {
                         newServer.setTcpNoDelay(tcpNoDelay);
                     }
 
+                    newServer.setReuseAddr(true);
+
                     try {
                         newServer.start();
                     } catch (IllegalStateException e) {


### PR DESCRIPTION
Allow re-use of port during Android socket shutdown timeout as outlined here: https://github.com/TooTallNate/Java-WebSocket/wiki/Enable-SO_REUSEADDR